### PR TITLE
Fix for posts rendering issue

### DIFF
--- a/baku/index.py
+++ b/baku/index.py
@@ -1,4 +1,5 @@
 import os
+from itertools import groupby
 from typing import List, Dict
 from baku import consts, post, templating, utils
 
@@ -8,16 +9,12 @@ def build_index(posts: List[post.Post], config: Dict[str, str]):
         os.path.join('templates', consts.ROOT_TEMPLATE))
 
     # Group posts by year
-    year, context, posts_in_year = posts[0].date.year, {'years': []}, []
-    for p in posts:
-        if p.date.year == year:
-            posts_in_year.append(p)
-        else:
-            context['years'].append({
-                'year': year,
-                'posts': posts_in_year
-            })
-            year, posts_in_year = p.date.year, [p]
+    context = {'years': []}
+    for year, posts_generator in groupby(sorted(posts, key=lambda x: x.date, reverse=True), key=lambda x: x.date.year):
+        context['years'].append({
+            'year': year,
+            'posts': list(posts_generator)
+        })
 
     with utils.open_utf8(os.path.join('.', 'html', 'index.html'), 'w+') as f:
         f.write(templating.render(template, context | config))


### PR DESCRIPTION
Modification to handle where only posts for one year was present. The current code in `index.py` did not render these posts, since they were never deposited in the `context`.

The `groupby` solution I added is more resilient.

And thank you for a simple and useful blog rendering tool!