### PR TITLE
add useful error when no posts exist

### DIFF
--- a/baku/index.py
+++ b/baku/index.py
@@ -7,6 +7,10 @@ def build_index(posts: List[post.Post], config: Dict[str, str]):
     template = templating.VerySimpleTemplate(
         os.path.join('templates', consts.ROOT_TEMPLATE))
 
+    if len(posts) == 0:
+        print("You have no posts. Create one with `baku --post <post name>`.")
+        return
+
     # Group posts by year
     year, context, posts_in_year = posts[0].date.year, {'years': []}, []
     for p in posts:


### PR DESCRIPTION
Ran into error migrating from tinkerer where I didn't have any posts yet and got a trace. Would be good to throw error earlier telling user why it is not building. 